### PR TITLE
All errors are logged, multiwriter implemented, Exit() statements cleaned up

### DIFF
--- a/merge/mergeRaw.go
+++ b/merge/mergeRaw.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	c "github.com/vrecan/MergeForward/c"
 	"strings"
+	"log"
+	"os"
 )
 
 type Value struct {
@@ -20,10 +22,12 @@ type Merge struct {
 var SPLIT = ":"
 
 //Merge the old values(src) into the new values (dst)
-func SimpleMerge(src string, dst string, split string, conf c.Conf) (result string, err error) {
+func SimpleMerge(src string, dst string, split string, conf c.Conf, logFile *os.File) (result string, err error) {
+	log.SetOutput(logFile)
 	SPLIT = split
 	reader := bytes.NewBufferString(src)
 	scanner := bufio.NewScanner(reader)
+
 	merge := &Merge{conf: conf}
 	for scanner.Scan() {
 		srcParts := strings.Split(scanner.Text(), SPLIT)
@@ -118,7 +122,9 @@ func Combine(src *Merge, dst *Merge) *Merge {
 				} else {
 					dstCnt[s.Key]++
 				}
-				if srcCnt[s.Key] == dstCnt[s.Key] {
+				if srcCnt[s.Key] == dstCnt[s.Key] && s.Value != d.Value {
+					log.Println("Replacing new {", d.Key + d.Value, "}")
+					log.Println("with the old  {", s.Key + s.Value, "}")
 					d.Value = s.Value
 				}
 			}

--- a/merge/mergeRaw.go
+++ b/merge/mergeRaw.go
@@ -27,8 +27,8 @@ func SimpleMerge(src string, dst string, split string, conf c.Conf, logFile *os.
 	SPLIT = split
 	reader := bytes.NewBufferString(src)
 	scanner := bufio.NewScanner(reader)
-
 	merge := &Merge{conf: conf}
+	
 	for scanner.Scan() {
 		srcParts := strings.Split(scanner.Text(), SPLIT)
 		merge.AddValues(srcParts)

--- a/merge/mergeRaw.go
+++ b/merge/mergeRaw.go
@@ -23,12 +23,13 @@ var SPLIT = ":"
 
 //Merge the old values(src) into the new values (dst)
 func SimpleMerge(src string, dst string, split string, conf c.Conf, logFile *os.File) (result string, err error) {
+	
 	log.SetOutput(logFile)
 	SPLIT = split
 	reader := bytes.NewBufferString(src)
 	scanner := bufio.NewScanner(reader)
 	merge := &Merge{conf: conf}
-	
+
 	for scanner.Scan() {
 		srcParts := strings.Split(scanner.Text(), SPLIT)
 		merge.AddValues(srcParts)

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -34,7 +34,7 @@ func TestMerge(t *testing.T) {
 		src := "yamlString: value"
 		dst := "yamlString: newValue"
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, src)
 	})
@@ -43,7 +43,7 @@ func TestMerge(t *testing.T) {
 		src := "yamlString= value"
 		dst := "yamlString= newValue"
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, "=", conf)
+		r, err := SimpleMerge(src, dst, "=", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, src)
 	})
@@ -65,7 +65,7 @@ func TestMerge(t *testing.T) {
 		new: "new:field:woo"
 		`
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, shouldResult)
 	})
@@ -87,7 +87,7 @@ func TestMerge(t *testing.T) {
 		`
 		conf := c.GetConf("")
 		conf.ConfigOverrides["override"] = ` "value:override:value:value"`
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, shouldResult)
 	})
@@ -98,7 +98,7 @@ func TestMerge(t *testing.T) {
 		`
 
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, "=", conf)
+		r, err := SimpleMerge(src, dst, "=", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, dst)
 	})
@@ -136,7 +136,7 @@ indexerConfList:
       inputQueueTimeoutSec: 5000
       passthroughQName: "customePass"`
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, shouldResult)
 	})
@@ -145,7 +145,7 @@ indexerConfList:
 		src := `something:`
 		dst := `something:`
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, dst)
 	})
@@ -154,7 +154,7 @@ indexerConfList:
 		src := `//comment block`
 		dst := `//comment`
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, dst)
 	})
@@ -167,7 +167,7 @@ indexerConfList:
 		shouldResult := `something: woo
 		something else: "new"`
 		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf)
+		r, err := SimpleMerge(src, dst, ":", conf, nil)
 		So(err, ShouldBeNil)
 		So(r, ShouldEqual, shouldResult)
 	})

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"log"
-	"io"
 
 )
 
@@ -18,44 +17,46 @@ var src = flag.String("src", "", "Source configuration file. Src values are pref
 var dst = flag.String("dst", "", "Destination configuration file.")
 var split = flag.String("split", ":", "Splitter for key value pairs")
 var config = flag.String("config", "./c.ini", "MergeForward configuration ini file")
-var outputdir = flag.String("outputdir", "", "The output directory of the log file")
+var outputdir = flag.String("outputdir", ".", "The output directory of the log file")
 
 type conf interface{}
 
 func main() {
 	flag.Parse()
 
+	fmt.Println("Log file will be created at", *outputdir + string(os.PathSeparator) + "MergeForward.log")
+
 	_ = os.Remove(*outputdir + "MergeForward.log")
-	logFile, err := os.OpenFile(*outputdir + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
+	logFile, err := os.OpenFile(*outputdir + string(os.PathSeparator) + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
 	if err != nil {
-		fmt.Println("Error making log file: " + *outputdir + string(os.PathSeparator) + "MergeForward.log")
+		fmt.Println("Error making log file:", *outputdir + string(os.PathSeparator) + "MergeForward.log")
 	}
 	defer logFile.Close()
-	
-	dualLogger := log.New(io.MultiWriter(logFile,os.Stdout), "", 0)
+
+	log.SetOutput(logFile)
 
 	if len(*src) == 0 {
-		dualLogger.Fatalln("No source file")
+		log.Fatalln("No source file")
 	}
 	if len(*dst) == 0 {
-		dualLogger.Fatalln("No destination file.")
+		log.Fatalln("No destination file.")
 	}
 	conf := c.GetConf(*config)
 
 	srcBytes, err := ioutil.ReadFile(*src)
 	if nil != err {
-		dualLogger.Fatalln("Unable to read src file: ", err)
+		log.Fatalln("Unable to read src file: ", err)
 	}
 
 	dstBytes, err := ioutil.ReadFile(*dst)
 	if nil != err {
-		dualLogger.Fatalln("Unable to read destination file: ", err)
+		log.Fatalln("Unable to read destination file: ", err)
 	}
 
 	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logFile)
 	if nil != err {
-		dualLogger.Fatalln("Unable to merge files: ", err)
+		log.Fatalln("Unable to merge files: ", err)
 	} else {
-		dualLogger.Println(result)
+		log.Println(result)
 	}
 }

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -26,6 +26,8 @@ func main() {
 
 	fmt.Println("Log file will be created at", *outputdir + string(os.PathSeparator) + "MergeForward.log")
 
+	os.MkdirAll(*outputdir, 0666)
+
 	_ = os.Remove(*outputdir + "MergeForward.log")
 	logFile, err := os.OpenFile(*outputdir + string(os.PathSeparator) + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
 	if err != nil {

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -9,45 +9,56 @@ import (
 	"github.com/vrecan/MergeForward/merge"
 	"io/ioutil"
 	"os"
+	"log"
 )
 
 var src = flag.String("src", "", "Source configuration file. Src values are prefered over dest.")
 var dst = flag.String("dst", "", "Destination configuration file.")
 var split = flag.String("split", ":", "Splitter for key value pairs")
 var config = flag.String("config", "./c.ini", "MergeForward configuration ini file")
+var outputdir = flag.String("outputdir", "", "The output directory of the log file")
 
 type conf interface{}
 
 func main() {
 	flag.Parse()
+
+	_ = os.Remove(*outputdir + "MergeForward.log")
+	logFile, err := os.OpenFile(*outputdir + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
+	if err != nil {
+		fmt.Println("Error making log file: " + *outputdir + string(os.PathSeparator) + "MergeForward.log")
+	}
+	defer logFile.Close()
+
+	log.SetOutput(logFile)
+
 	if len(*src) == 0 {
-		fmt.Println("No source file.")
+		log.Println("No source file.")
 		os.Exit(1)
 	}
 	if len(*dst) == 0 {
-		fmt.Println("No destination file.")
+		log.Println("No destination file.")
 		os.Exit(1)
 	}
 	conf := c.GetConf(*config)
 
 	srcBytes, err := ioutil.ReadFile(*src)
 	if nil != err {
-		fmt.Println("Unable to read src file: ", err)
+		log.Println("Unable to read src file: ", err)
 		os.Exit(1)
 	}
 
 	dstBytes, err := ioutil.ReadFile(*dst)
 	if nil != err {
-		fmt.Println("Unable to read destination file: ", err)
+		log.Println("Unable to read destination file: ", err)
 		os.Exit(1)
 	}
 
-	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf)
+	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logFile)
 	if nil != err {
-		fmt.Println("Unable to merge files: ", err)
+		log.Println("Unable to merge files: ", err)
 		os.Exit(1)
 	} else {
-		//output to stdout
-		fmt.Print(result)
+		log.Println(result)
 	}
 }

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -56,9 +56,11 @@ func main() {
 
 	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logFile)
 	if nil != err {
+		fmt.Println("Unable to merge files: ", err)
 		log.Println("Unable to merge files: ", err)
 		os.Exit(1)
 	} else {
+		fmt.Println(result)
 		log.Println(result)
 	}
 }

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -10,6 +10,8 @@ import (
 	"io/ioutil"
 	"os"
 	"log"
+	"io"
+
 )
 
 var src = flag.String("src", "", "Source configuration file. Src values are prefered over dest.")
@@ -29,38 +31,31 @@ func main() {
 		fmt.Println("Error making log file: " + *outputdir + string(os.PathSeparator) + "MergeForward.log")
 	}
 	defer logFile.Close()
-
-	log.SetOutput(logFile)
+	
+	dualLogger := log.New(io.MultiWriter(logFile,os.Stdout), "", 0)
 
 	if len(*src) == 0 {
-		log.Println("No source file.")
-		os.Exit(1)
+		dualLogger.Fatalln("No source file")
 	}
 	if len(*dst) == 0 {
-		log.Println("No destination file.")
-		os.Exit(1)
+		dualLogger.Fatalln("No destination file.")
 	}
 	conf := c.GetConf(*config)
 
 	srcBytes, err := ioutil.ReadFile(*src)
 	if nil != err {
-		log.Println("Unable to read src file: ", err)
-		os.Exit(1)
+		dualLogger.Fatalln("Unable to read src file: ", err)
 	}
 
 	dstBytes, err := ioutil.ReadFile(*dst)
 	if nil != err {
-		log.Println("Unable to read destination file: ", err)
-		os.Exit(1)
+		dualLogger.Fatalln("Unable to read destination file: ", err)
 	}
 
 	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logFile)
 	if nil != err {
-		fmt.Println("Unable to merge files: ", err)
-		log.Println("Unable to merge files: ", err)
-		os.Exit(1)
+		dualLogger.Fatalln("Unable to merge files: ", err)
 	} else {
-		fmt.Println(result)
-		log.Println(result)
+		dualLogger.Println(result)
 	}
 }


### PR DESCRIPTION
- Standard out receives all output except for the line-by-line replacement messages.
- MergeForward.log is now created in the current directory by default and contains errors and the values that are replaced during the merge. 
- Log output directory can be customized by the -outputdir flag (ex. -outputdir ...../example/directory/)
