### PR TITLE
Seelog is now integrated into MergeForward

### DIFF
--- a/merge/mergeRaw.go
+++ b/merge/mergeRaw.go
@@ -5,8 +5,7 @@ import (
 	"bytes"
 	c "github.com/vrecan/MergeForward/c"
 	"strings"
-	"log"
-	"os"
+    "github.com/cihub/seelog"
 )
 
 type Value struct {
@@ -19,12 +18,14 @@ type Merge struct {
 	conf   c.Conf
 }
 
+var logger seelog.LoggerInterface
 var SPLIT = ":"
 
 //Merge the old values(src) into the new values (dst)
-func SimpleMerge(src string, dst string, split string, conf c.Conf, logFile *os.File) (result string, err error) {
-	
-	log.SetOutput(logFile)
+func SimpleMerge(src string, dst string, split string, conf c.Conf, seelogLogger seelog.LoggerInterface) (result string, err error) {
+
+    logger = seelogLogger
+
 	SPLIT = split
 	reader := bytes.NewBufferString(src)
 	scanner := bufio.NewScanner(reader)
@@ -124,8 +125,8 @@ func Combine(src *Merge, dst *Merge) *Merge {
 					dstCnt[s.Key]++
 				}
 				if srcCnt[s.Key] == dstCnt[s.Key] && s.Value != d.Value {
-					log.Println("Replacing new {", d.Key + d.Value, "}")
-					log.Println("with the old  {", s.Key + s.Value, "}")
+					logger.Info("Replacing new {", d.Key + d.Value, "}")
+					logger.Info("with the old  {", s.Key + s.Value, "}")
 					d.Value = s.Value
 				}
 			}

--- a/merge/mergeRaw.go
+++ b/merge/mergeRaw.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	c "github.com/vrecan/MergeForward/c"
 	"strings"
-    "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 )
 
 type Value struct {
@@ -24,7 +24,7 @@ var SPLIT = ":"
 //Merge the old values(src) into the new values (dst)
 func SimpleMerge(src string, dst string, split string, conf c.Conf, seelogLogger seelog.LoggerInterface) (result string, err error) {
 
-    logger = seelogLogger
+	logger = seelogLogger
 
 	SPLIT = split
 	reader := bytes.NewBufferString(src)

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -4,107 +4,140 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	c "github.com/vrecan/MergeForward/c"
 	"testing"
+	"github.com/cihub/seelog"
+	"log"
 )
 
 var conf c.Conf
 
 func TestMerge(t *testing.T) {
-	Convey("override an exact match", t, func() {
-		conf := c.GetConf("")
-		conf.ConfigOverrides["override"] = ` "value:override:value:value"`
-		d := &Value{Key: "override", Value: `:  "value:value:value:value"`}
-		override(d, conf)
-		So(d.Value, ShouldEqual, `: "value:override:value:value"`)
-	})
-	Convey("override contains match", t, func() {
-		conf := c.GetConf("")
-		conf.ConfigOverrides["override"] = ` "value:override:value:value"`
-		d := &Value{Key: "stuff override stuff", Value: `: "value:value:value:value"`}
-		override(d, conf)
-		So(d.Value, ShouldEqual, `: "value:override:value:value"`)
-	})
-	Convey("override contains match but no separator on matched line", t, func() {
-		conf := c.GetConf("")
-		conf.ConfigOverrides["data"] = ` D:\data`
-		d := &Value{Key: "   data", Value: ``}
-		override(d, conf)
-		So(d.Value, ShouldEqual, ``)
-	})
-	Convey("Merge simple string", t, func() {
-		src := "yamlString: value"
-		dst := "yamlString: newValue"
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, src)
-	})
 
-	Convey("Merge with = delimiter", t, func() {
-		src := "yamlString= value"
-		dst := "yamlString= newValue"
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, "=", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, src)
-	})
+	Convey("Build seelog logger", t, func() {
 
-	Convey("Merge with multiline conf", t, func() {
-		src := `yamlString: value
+		logger, err := seelog.LoggerFromConfigAsString(
+			"<seelog type=\"asynctimer\" asyncinterval=\"1000000\">" +
+			"<outputs formatid=\"all\">" +
+			"<filter levels=\"info\" formatid=\"fmtinfo\">" +
+			"<console/>" +
+			"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+			"</filter>" +
+			"<filter levels=\"warn\" formatid=\"fmtwarn\">" +
+			"<console/>" +
+			"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+			"</filter>" +
+			"<filter levels=\"error,critical\" formatid=\"fmterror\">" +
+			"<console/>" +
+			"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+			"</filter>" +
+			"</outputs>" +
+			"<formats>" +
+			"<format id=\"fmtinfo\" format=\"%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n\"/>" +
+			"<format id=\"fmterror\" format=\"%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+			"<format id=\"fmtwarn\" format=\"%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+			"<format id=\"all\" format=\"%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+			"</formats>" +
+			"</seelog>")
+
+		if err != nil {
+			log.Fatal(err, "- This error happened while automatically detecting the current directory of mergeforward")
+		}
+
+		Convey("override an exact match", func() {
+			conf := c.GetConf("")
+			conf.ConfigOverrides["override"] = ` "value:override:value:value"`
+			d := &Value{Key: "override", Value: `:  "value:value:value:value"`}
+			override(d, conf)
+			So(d.Value, ShouldEqual, `: "value:override:value:value"`)
+		})
+		Convey("override contains match", func() {
+			conf := c.GetConf("")
+			conf.ConfigOverrides["override"] = ` "value:override:value:value"`
+			d := &Value{Key: "stuff override stuff", Value: `: "value:value:value:value"`}
+			override(d, conf)
+			So(d.Value, ShouldEqual, `: "value:override:value:value"`)
+		})
+		Convey("override contains match but no separator on matched line", func() {
+			conf := c.GetConf("")
+			conf.ConfigOverrides["data"] = ` D:\data`
+			d := &Value{Key: "   data", Value: ``}
+			override(d, conf)
+			So(d.Value, ShouldEqual, ``)
+		})
+		Convey("Merge simple string", func() {
+			src := "yamlString: value"
+			dst := "yamlString: newValue"
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, src)
+		})
+
+		Convey("Merge with = delimiter", func() {
+			src := "yamlString= value"
+			dst := "yamlString= newValue"
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, "=", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, src)
+		})
+
+		Convey("Merge with multiline conf", func() {
+			src := `yamlString: value
 		value: "value:change:value:value"
 		other: "other:other:other:other"
 		`
-		dst := `yamlString: value
+			dst := `yamlString: value
 		value: "value:value:value:value"
 		other: "other:other:other:other"
 		new: "new:field:woo"
 		`
 
-		shouldResult := `yamlString: value
+			shouldResult := `yamlString: value
 		value: "value:change:value:value"
 		other: "other:other:other:other"
 		new: "new:field:woo"
 		`
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, shouldResult)
-	})
-	Convey("Merge with multiline conf and overrides", t, func() {
-		src := `yamlString : value
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, shouldResult)
+		})
+		Convey("Merge with multiline conf and overrides", func() {
+			src := `yamlString : value
 		value : "value:change:value:value"
 		override : "value:value:value:value"
 		`
-		dst := `yamlString : value
+			dst := `yamlString : value
 		value : "value:value:value:value"
 		override : "value:value:value:value"
 		new : "new:field:woo"
 		`
 
-		shouldResult := `yamlString : value
+			shouldResult := `yamlString : value
 		value : "value:change:value:value"
 		override : "value:override:value:value"
 		new : "new:field:woo"
 		`
-		conf := c.GetConf("")
-		conf.ConfigOverrides["override"] = ` "value:override:value:value"`
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, shouldResult)
-	})
-	Convey("Ignore strings with no delimiter", t, func() {
-		src := "!!YAMLthingy.com.company.objectname"
-		dst := `!!YAMLthingy.com.company.objectname
+			conf := c.GetConf("")
+			conf.ConfigOverrides["override"] = ` "value:override:value:value"`
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, shouldResult)
+		})
+		Convey("Ignore strings with no delimiter", func() {
+			src := "!!YAMLthingy.com.company.objectname"
+			dst := `!!YAMLthingy.com.company.objectname
 		somethingElse: "value"
 		`
 
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, "=", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, dst)
-	})
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, "=", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, dst)
+		})
 
-	Convey("Test yaml lists with same object should replace in order", t, func() {
-		src := `!!com.company.configelements.DispatchConfigMessage
+		Convey("Test yaml lists with same object should replace in order", func() {
+			src := `!!com.company.configelements.DispatchConfigMessage
 indexerConfList:
    - !!com.company.configelements.DispatchConfigMessage$IndexerConfigMessage
       inputQueue: tcp://0.0.0.0:13109
@@ -114,7 +147,7 @@ indexerConfList:
       inputQueue: tcp://127.0.0.1:13102
       inputQueueTimeoutSec: 5000
       passthroughQName: "customePass"`
-		dst := `!!com.company.configelements.DispatchConfigMessage
+			dst := `!!com.company.configelements.DispatchConfigMessage
 indexerConfList:
    - !!com.company.configelements.DispatchConfigMessage$IndexerConfigMessage
       inputQueue: tcp://*:13100
@@ -125,7 +158,7 @@ indexerConfList:
       inputQueueTimeoutSec: 5000
       passthroughQName: ""`
 
-		shouldResult := `!!com.company.configelements.DispatchConfigMessage
+			shouldResult := `!!com.company.configelements.DispatchConfigMessage
 indexerConfList:
    - !!com.company.configelements.DispatchConfigMessage$IndexerConfigMessage
       inputQueue: tcp://0.0.0.0:13109
@@ -135,41 +168,41 @@ indexerConfList:
       inputQueue: tcp://127.0.0.1:13102
       inputQueueTimeoutSec: 5000
       passthroughQName: "customePass"`
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, shouldResult)
-	})
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, shouldResult)
+		})
 
-	Convey("empty value test", t, func() {
-		src := `something:`
-		dst := `something:`
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, dst)
-	})
+		Convey("empty value test", func() {
+			src := `something:`
+			dst := `something:`
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, dst)
+		})
 
-	Convey("comment block test update", t, func() {
-		src := `//comment block`
-		dst := `//comment`
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, dst)
-	})
-	Convey("comment block test update with :", t, func() {
-		src := `something: woo
+		Convey("comment block test update", func() {
+			src := `//comment block`
+			dst := `//comment`
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, dst)
+		})
+		Convey("comment block test update with :", func() {
+			src := `something: woo
 		//comment explaining something else
 		something else: "new"`
-		dst := `something: woo
+			dst := `something: woo
 		something else: "woo"`
-		shouldResult := `something: woo
+			shouldResult := `something: woo
 		something else: "new"`
-		conf := c.GetConf("")
-		r, err := SimpleMerge(src, dst, ":", conf, nil)
-		So(err, ShouldBeNil)
-		So(r, ShouldEqual, shouldResult)
+			conf := c.GetConf("")
+			r, err := SimpleMerge(src, dst, ":", conf, logger)
+			So(err, ShouldBeNil)
+			So(r, ShouldEqual, shouldResult)
+		})
 	})
-
 }

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -15,28 +15,28 @@ func TestMerge(t *testing.T) {
 	Convey("Build seelog logger", t, func() {
 
 		logger, err := seelog.LoggerFromConfigAsString(
-			"<seelog type=\"asynctimer\" asyncinterval=\"1000000\">" +
-			"<outputs formatid=\"all\">" +
-			"<filter levels=\"info\" formatid=\"fmtinfo\">" +
-			"<console/>" +
-			"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-			"</filter>" +
-			"<filter levels=\"warn\" formatid=\"fmtwarn\">" +
-			"<console/>" +
-			"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-			"</filter>" +
-			"<filter levels=\"error,critical\" formatid=\"fmterror\">" +
-			"<console/>" +
-			"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-			"</filter>" +
-			"</outputs>" +
-			"<formats>" +
-			"<format id=\"fmtinfo\" format=\"%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n\"/>" +
-			"<format id=\"fmterror\" format=\"%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-			"<format id=\"fmtwarn\" format=\"%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-			"<format id=\"all\" format=\"%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-			"</formats>" +
-			"</seelog>")
+			`<seelog type="asynctimer" asyncinterval="1000000">` +
+			`<outputs formatid="all">` +
+			`<filter levels="info" formatid="fmtinfo">` +
+			`<console/>` +
+			`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+			`</filter>` +
+			`<filter levels="warn" formatid="fmtwarn">` +
+			`<console/>` +
+			`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+			`</filter>` +
+			`<filter levels="error,critical" formatid="fmterror">` +
+			`<console/>` +
+			`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+			`</filter>` +
+			`</outputs>` +
+			`<formats>` +
+			`<format id="fmtinfo" format="%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n"/>` +
+			`<format id="fmterror" format="%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+			`<format id="fmtwarn" format="%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+			`<format id="all" format="%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+			`</formats>` +
+			`</seelog>`)
 
 		if err != nil {
 			log.Fatal(err, "- This error happened while automatically detecting the current directory of mergeforward")

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -16,26 +16,26 @@ func TestMerge(t *testing.T) {
 
 		logger, err := seelog.LoggerFromConfigAsString(
 			`<seelog type="asynctimer" asyncinterval="1000000">` +
-			`<outputs formatid="all">` +
-			`<filter levels="info" formatid="fmtinfo">` +
-			`<console/>` +
-			`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
-			`</filter>` +
-			`<filter levels="warn" formatid="fmtwarn">` +
-			`<console/>` +
-			`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
-			`</filter>` +
-			`<filter levels="error,critical" formatid="fmterror">` +
-			`<console/>` +
-			`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
-			`</filter>` +
-			`</outputs>` +
-			`<formats>` +
-			`<format id="fmtinfo" format="%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n"/>` +
-			`<format id="fmterror" format="%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
-			`<format id="fmtwarn" format="%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
-			`<format id="all" format="%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
-			`</formats>` +
+				`<outputs formatid="all">` +
+					`<filter levels="info" formatid="fmtinfo">` +
+						`<console/>` +
+						`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+					`</filter>` +
+					`<filter levels="warn" formatid="fmtwarn">` +
+						`<console/>` +
+						`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+					`</filter>` +
+					`<filter levels="error,critical" formatid="fmterror">` +
+						`<console/>` +
+						`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+					`</filter>` +
+				`</outputs>` +
+				`<formats>` +
+					`<format id="fmtinfo" format="%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n"/>` +
+					`<format id="fmterror" format="%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+					`<format id="fmtwarn" format="%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+					`<format id="all" format="%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+				`</formats>` +
 			`</seelog>`)
 
 		if err != nil {

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -42,6 +42,8 @@ func TestMerge(t *testing.T) {
 			log.Fatal(err, "- This error happened while automatically detecting the current directory of mergeforward")
 		}
 
+		defer logger.Close()
+
 		Convey("override an exact match", func() {
 			conf := c.GetConf("")
 			conf.ConfigOverrides["override"] = ` "value:override:value:value"`

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -68,7 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
-    logger.Info("Merging ", *src, " into ", *dst, "...")
+	logger.Info("Merging ", *src, " into ", *dst, "...")
 
 	conf := c.GetConf(*config)
 

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -18,7 +18,6 @@ var src = flag.String("src", "", "Source configuration file. Src values are pref
 var dst = flag.String("dst", "", "Destination configuration file.")
 var split = flag.String("split", ":", "Splitter for key value pairs")
 var config = flag.String("config", "./c.ini", "MergeForward configuration ini file")
-var outputdir = flag.String("outputdir", ".", "The output directory of the log file")
 
 type conf interface{}
 
@@ -33,37 +32,31 @@ func main() {
 	fmt.Println(currentDirectory)
 
 	logger, err := seelog.LoggerFromConfigAsString(
-		"<seelog type=\"asynctimer\" asyncinterval=\"1000000\">" +
-			"<outputs formatid=\"all\">" +
-				"<filter levels=\"info\" formatid=\"fmtinfo\">" +
-					"<console/>" +
-					"<rollingfile type=\"size\" filename=\"/var/log/persistent/MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-				"</filter>" +
-				"<filter levels=\"warn\" formatid=\"fmtwarn\">" +
-					"<console/>" +
-					"<rollingfile type=\"size\" filename=\"/var/log/persistent/MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-				"</filter>" +
-				"<filter levels=\"error,critical\" formatid=\"fmterror\">" +
-					"<console/>" +
-					"<rollingfile type=\"size\" filename=\"/var/log/persistent/MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-				"</filter>" +
-			"</outputs>" +
-			"<formats>" +
-				"<format id=\"fmtinfo\" format=\"%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n\"/>" +
-				"<format id=\"fmterror\" format=\"%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-				"<format id=\"fmtwarn\" format=\"%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-				"<format id=\"all\" format=\"%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-			"</formats>" +
-		"</seelog>")
+		`<seelog type="asynctimer" asyncinterval="1000000">` +
+			`<outputs formatid="all">` +
+				`<filter levels="info" formatid="fmtinfo">` +
+					`<console/>` +
+					`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+				`</filter>` +
+				`<filter levels="warn" formatid="fmtwarn">` +
+					`<console/>` +
+					`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+				`</filter>` +
+				`<filter levels="error,critical" formatid="fmterror">` +
+					`<console/>` +
+					`<rollingfile type="size" filename="/var/log/persistent/MergeForward.log" maxsize="20000000" maxrolls="5" />` +
+				`</filter>` +
+			`</outputs>` +
+			`<formats>` +
+				`<format id="fmtinfo" format="%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n"/>` +
+				`<format id="fmterror" format="%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+				`<format id="fmtwarn" format="%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+				`<format id="all" format="%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n"/>` +
+			`</formats>` +
+		`</seelog>`)
 
 	flag.Parse()
 
-	os.MkdirAll(*outputdir, 0666)
-
-	_ = os.Remove(*outputdir + "MergeForward.log")
-	if err != nil {
-		fmt.Println("Error making log file:", *outputdir + string(os.PathSeparator) + "MergeForward.log")
-	}
 	defer logger.Close()
 
 	if len(*src) == 0 {
@@ -74,6 +67,9 @@ func main() {
 		logger.Critical("No destination file.")
 		os.Exit(1)
 	}
+
+    logger.Info("Merging ", *src, " into ", *dst, "...")
+
 	conf := c.GetConf(*config)
 
 	srcBytes, err := ioutil.ReadFile(*src)
@@ -94,6 +90,6 @@ func main() {
 		os.Exit(1)
 	} else {
 		fmt.Println(result)
-		logger.Info("Final file output:\n" + result)
+		logger.Info("Final file output:\n" + result + "\n")
 	}
 }

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -10,8 +10,8 @@ import (
 	"io/ioutil"
 	"os"
 	"github.com/cihub/seelog"
-    "path/filepath"
-    "log"
+	"path/filepath"
+	"log"
 )
 
 var src = flag.String("src", "", "Source configuration file. Src values are prefered over dest.")
@@ -24,77 +24,76 @@ type conf interface{}
 
 func main() {
 
-    currentDirectory, err := filepath.Abs(filepath.Dir(os.Args[0]))
-    if err != nil {
-        log.Fatal(err, "- This error happened while automatically detecting the current directory of mergeforward")
-    }
+	currentDirectory, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		log.Fatal(err, "- This error happened while automatically detecting the current directory of mergeforward")
+	}
 
-    fmt.Print("Printing current directory: ")
-    fmt.Println(currentDirectory)
+	fmt.Print("Printing current directory: ")
+	fmt.Println(currentDirectory)
 
 	logger, err := seelog.LoggerFromConfigAsString(
-        "<seelog type=\"asynctimer\" asyncinterval=\"1000000\">" +
-	        "<outputs formatid=\"all\">" +
-	            "<filter levels=\"info\" formatid=\"fmtinfo\">" +
-	                "<console/>" +
-	                "<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-	            "</filter>" +
-	            "<filter levels=\"warn\" formatid=\"fmtwarn\">" +
-	                "<console/>" +
-	                "<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-	            "</filter>" +
-	            "<filter levels=\"error,critical\" formatid=\"fmterror\">" +
-	                "<console/>" +
-	                "<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
-	            "</filter>" +
-	        "</outputs>" +
-            "<formats>" +
-	            "<format id=\"fmtinfo\" format=\"%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n\"/>" +
-	            "<format id=\"fmterror\" format=\"%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-	            "<format id=\"fmtwarn\" format=\"%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-	            "<format id=\"all\" format=\"%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
-	        "</formats>" +
-        "</seelog>")
+		"<seelog type=\"asynctimer\" asyncinterval=\"1000000\">" +
+			"<outputs formatid=\"all\">" +
+				"<filter levels=\"info\" formatid=\"fmtinfo\">" +
+					"<console/>" +
+					"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+				"</filter>" +
+				"<filter levels=\"warn\" formatid=\"fmtwarn\">" +
+					"<console/>" +
+					"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+				"</filter>" +
+				"<filter levels=\"error,critical\" formatid=\"fmterror\">" +
+					"<console/>" +
+					"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+				"</filter>" +
+			"</outputs>" +
+			"<formats>" +
+				"<format id=\"fmtinfo\" format=\"%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n\"/>" +
+				"<format id=\"fmterror\" format=\"%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+				"<format id=\"fmtwarn\" format=\"%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+				"<format id=\"all\" format=\"%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+			"</formats>" +
+		"</seelog>")
 
 	flag.Parse()
 
 	os.MkdirAll(*outputdir, 0666)
 
 	_ = os.Remove(*outputdir + "MergeForward.log")
-//	logFile, err := os.OpenFile(*outputdir + string(os.PathSeparator) + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
 	if err != nil {
 		fmt.Println("Error making log file:", *outputdir + string(os.PathSeparator) + "MergeForward.log")
 	}
 	defer logger.Close()
 
 	if len(*src) == 0 {
-        logger.Critical("No source file")
-        os.Exit(-1)
+		logger.Critical("No source file")
+		os.Exit(1)
 	}
 	if len(*dst) == 0 {
-        logger.Critical("No destination file.")
-        os.Exit(-1)
+		logger.Critical("No destination file.")
+		os.Exit(1)
 	}
 	conf := c.GetConf(*config)
 
 	srcBytes, err := ioutil.ReadFile(*src)
 	if nil != err {
-        logger.Critical("Unable to read src file: ", err)
-        os.Exit(-1)
+		logger.Critical("Unable to read src file: ", err)
+		os.Exit(1)
 	}
 
 	dstBytes, err := ioutil.ReadFile(*dst)
 	if nil != err {
 		logger.Critical("Unable to read destination file: ", err)
-        os.Exit(-1)
+		os.Exit(1)
 	}
 
 	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logger)
 	if nil != err {
 		logger.Critical("Unable to merge files: ", err)
-        os.Exit(-1)
+		os.Exit(1)
 	} else {
 		fmt.Println(result)
-        logger.Info("Final file output:\n" + result)
+		logger.Info("Final file output:\n" + result)
 	}
 }

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -37,15 +37,15 @@ func main() {
 			"<outputs formatid=\"all\">" +
 				"<filter levels=\"info\" formatid=\"fmtinfo\">" +
 					"<console/>" +
-					"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+					"<rollingfile type=\"size\" filename=\"/var/log/persistent/MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
 				"</filter>" +
 				"<filter levels=\"warn\" formatid=\"fmtwarn\">" +
 					"<console/>" +
-					"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+					"<rollingfile type=\"size\" filename=\"/var/log/persistent/MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
 				"</filter>" +
 				"<filter levels=\"error,critical\" formatid=\"fmterror\">" +
 					"<console/>" +
-					"<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+					"<rollingfile type=\"size\" filename=\"/var/log/persistent/MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
 				"</filter>" +
 			"</outputs>" +
 			"<formats>" +

--- a/mergeforward.go
+++ b/mergeforward.go
@@ -9,8 +9,9 @@ import (
 	"github.com/vrecan/MergeForward/merge"
 	"io/ioutil"
 	"os"
-	"log"
-
+	"github.com/cihub/seelog"
+    "path/filepath"
+    "log"
 )
 
 var src = flag.String("src", "", "Source configuration file. Src values are prefered over dest.")
@@ -22,42 +23,78 @@ var outputdir = flag.String("outputdir", ".", "The output directory of the log f
 type conf interface{}
 
 func main() {
+
+    currentDirectory, err := filepath.Abs(filepath.Dir(os.Args[0]))
+    if err != nil {
+        log.Fatal(err, "- This error happened while automatically detecting the current directory of mergeforward")
+    }
+
+    fmt.Print("Printing current directory: ")
+    fmt.Println(currentDirectory)
+
+	logger, err := seelog.LoggerFromConfigAsString(
+        "<seelog type=\"asynctimer\" asyncinterval=\"1000000\">" +
+	        "<outputs formatid=\"all\">" +
+	            "<filter levels=\"info\" formatid=\"fmtinfo\">" +
+	                "<console/>" +
+	                "<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+	            "</filter>" +
+	            "<filter levels=\"warn\" formatid=\"fmtwarn\">" +
+	                "<console/>" +
+	                "<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+	            "</filter>" +
+	            "<filter levels=\"error,critical\" formatid=\"fmterror\">" +
+	                "<console/>" +
+	                "<rollingfile type=\"size\" filename=\"MergeForward.log\" maxsize=\"20000000\" maxrolls=\"5\" />" +
+	            "</filter>" +
+	        "</outputs>" +
+            "<formats>" +
+	            "<format id=\"fmtinfo\" format=\"%EscM(32)[%Level]%EscM(0) [%Date %Time] [%File] %Msg%n\"/>" +
+	            "<format id=\"fmterror\" format=\"%EscM(31)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+	            "<format id=\"fmtwarn\" format=\"%EscM(33)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+	            "<format id=\"all\" format=\"%EscM(2)[%LEVEL]%EscM(0) [%Date %Time] [%FuncShort @ %File.%Line] %Msg%n\"/>" +
+	        "</formats>" +
+        "</seelog>")
+
 	flag.Parse()
 
 	os.MkdirAll(*outputdir, 0666)
 
 	_ = os.Remove(*outputdir + "MergeForward.log")
-	logFile, err := os.OpenFile(*outputdir + string(os.PathSeparator) + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
+//	logFile, err := os.OpenFile(*outputdir + string(os.PathSeparator) + "MergeForward.log", os.O_RDWR | os.O_CREATE, 0666)
 	if err != nil {
 		fmt.Println("Error making log file:", *outputdir + string(os.PathSeparator) + "MergeForward.log")
 	}
-	defer logFile.Close()
-
-	log.SetOutput(logFile)
+	defer logger.Close()
 
 	if len(*src) == 0 {
-		log.Fatalln("No source file")
+        logger.Critical("No source file")
+        os.Exit(-1)
 	}
 	if len(*dst) == 0 {
-		log.Fatalln("No destination file.")
+        logger.Critical("No destination file.")
+        os.Exit(-1)
 	}
 	conf := c.GetConf(*config)
 
 	srcBytes, err := ioutil.ReadFile(*src)
 	if nil != err {
-		log.Fatalln("Unable to read src file: ", err)
+        logger.Critical("Unable to read src file: ", err)
+        os.Exit(-1)
 	}
 
 	dstBytes, err := ioutil.ReadFile(*dst)
 	if nil != err {
-		log.Fatalln("Unable to read destination file: ", err)
+		logger.Critical("Unable to read destination file: ", err)
+        os.Exit(-1)
 	}
 
-	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logFile)
+	result, err := merge.SimpleMerge(string(srcBytes), string(dstBytes), *split, conf, logger)
 	if nil != err {
-		log.Fatalln("Unable to merge files: ", err)
+		logger.Critical("Unable to merge files: ", err)
+        os.Exit(-1)
 	} else {
 		fmt.Println(result)
-		log.Println(result)
+        logger.Info("Final file output:\n" + result)
 	}
 }


### PR DESCRIPTION
The test file looks pretty gross on the merge view, but the gist of it is I made a blanket Convey statement that sets up the seelog logger. Every test is nested within that. In order to do this, I left the test object out of every sub-convey statement call since the setup step had the reference to in.
